### PR TITLE
Rename regions to solids. 

### DIFF
--- a/entity_mapper.py
+++ b/entity_mapper.py
@@ -25,7 +25,7 @@ class EntityMapper:
         # PythonOCC hash values to the indices used in 
         # the topology file
         self.body_map = dict()
-        self.region_map = dict()
+        self.lump_map = dict()
         self.shell_map = dict()
         self.face_map = dict()
         self.loop_map = dict()
@@ -50,7 +50,7 @@ class EntityMapper:
 
             # Build the index lookup tables
             self.append_body(body)
-            self.append_regions(top_exp)
+            self.append_lumps(top_exp)
             self.append_shells(top_exp)
             self.append_faces(top_exp)
             self.append_loops(top_exp)
@@ -79,12 +79,12 @@ class EntityMapper:
         h = self.get_hash(body)
         return self.body_map[h]
 
-    def region_index(self, region):
+    def lump_index(self, lump):
         """
-        Find the index of a region
+        Find the index of a lump
         """
-        h = self.get_hash(region)
-        return self.region_map[h]
+        h = self.get_hash(lump)
+        return self.lump_map[h]
 
     def shell_index(self, shell):
         """
@@ -152,16 +152,16 @@ class EntityMapper:
         assert not h in self.body_map
         self.body_map[h] = index
 
-    def append_regions(self, top_exp):
-        regions = top_exp.solids()
-        for region in regions:
-            self.append_region(region)
+    def append_lumps(self, top_exp):
+        lumps = top_exp.solids()
+        for lump in lumps:
+            self.append_lump(lump)
 
-    def append_region(self, region):
-        h = self.get_hash(region)
-        index = len(self.region_map)
-        assert not h in self.region_map
-        self.region_map[h] = index
+    def append_lump(self, lump):
+        h = self.get_hash(lump)
+        index = len(self.lump_map)
+        assert not h in self.lump_map
+        self.lump_map[h] = index
 
     def append_shells(self, top_exp):
         shells = top_exp.shells()

--- a/entity_mapper.py
+++ b/entity_mapper.py
@@ -25,7 +25,7 @@ class EntityMapper:
         # PythonOCC hash values to the indices used in 
         # the topology file
         self.body_map = dict()
-        self.lump_map = dict()
+        self.solid_map = dict()
         self.shell_map = dict()
         self.face_map = dict()
         self.loop_map = dict()
@@ -50,7 +50,7 @@ class EntityMapper:
 
             # Build the index lookup tables
             self.append_body(body)
-            self.append_lumps(top_exp)
+            self.append_solids(top_exp)
             self.append_shells(top_exp)
             self.append_faces(top_exp)
             self.append_loops(top_exp)
@@ -79,12 +79,12 @@ class EntityMapper:
         h = self.get_hash(body)
         return self.body_map[h]
 
-    def lump_index(self, lump):
+    def solid_index(self, solid):
         """
-        Find the index of a lump
+        Find the index of a solid
         """
-        h = self.get_hash(lump)
-        return self.lump_map[h]
+        h = self.get_hash(solid)
+        return self.solid_map[h]
 
     def shell_index(self, shell):
         """
@@ -152,16 +152,16 @@ class EntityMapper:
         assert not h in self.body_map
         self.body_map[h] = index
 
-    def append_lumps(self, top_exp):
-        lumps = top_exp.solids()
-        for lump in lumps:
-            self.append_lump(lump)
+    def append_solids(self, top_exp):
+        solids = top_exp.solids()
+        for solid in solids:
+            self.append_solid(solid)
 
-    def append_lump(self, lump):
-        h = self.get_hash(lump)
-        index = len(self.lump_map)
-        assert not h in self.lump_map
-        self.lump_map[h] = index
+    def append_solid(self, solid):
+        h = self.get_hash(solid)
+        index = len(self.solid_map)
+        assert not h in self.solid_map
+        self.solid_map[h] = index
 
     def append_shells(self, top_exp):
         shells = top_exp.shells()

--- a/topology_dict_builder.py
+++ b/topology_dict_builder.py
@@ -20,13 +20,13 @@ class TopologyDictBuilder:
     A class which builds a python dictionary
     ready for export to the topology file
     """
-    def __init__(self, entity_mapper):
+    def __init__(self, entity_mapper, allow_nonmanifold = False):
         """
         Construct from the entity mapper which gives
         us a mapping between the 
         """
         self.entity_mapper = entity_mapper
-
+        self.allow_nonmanifold = allow_nonmanifold
 
     def build_dict_for_bodies(self, bodies):
         """
@@ -36,7 +36,7 @@ class TopologyDictBuilder:
             bodies = [bodies]
             
         body_dict = {
-            "regions": self.build_regions_array(bodies),
+            "lumps": self.build_lumps_array(bodies),
             "shells": self.build_shells_array(bodies),
             "faces": self.build_faces_array(bodies),
             "edges": self.build_edges_array(bodies),
@@ -54,16 +54,16 @@ class TopologyDictBuilder:
             bodies_arr.append(self.build_body_data(body))
         return bodies_arr
 
-    def build_regions_array(self, bodies):
-        regions_arr = []
+    def build_lumps_array(self, bodies):
+        lumps_arr = []
         for body in bodies:
             top_exp = TopologyExplorer(body)
-            regions = top_exp.solids()
-            for region in regions:
-                expected_region_index = self.entity_mapper.region_index(region)
-                assert expected_region_index == len(regions_arr)
-                regions_arr.append(self.build_region_data(top_exp, region))
-        return regions_arr
+            lumps = top_exp.solids()
+            for lump in lumps:
+                expected_lump_index = self.entity_mapper.lump_index(lump)
+                assert expected_lump_index == len(lumps_arr)
+                lumps_arr.append(self.build_lump_data(top_exp, lump))
+        return lumps_arr
         
 
     def build_shells_array(self, bodies):
@@ -132,19 +132,19 @@ class TopologyDictBuilder:
         return halfedges_arr
 
     def build_body_data(self, body):
-        region_indices = []
+        lump_indices = []
         top_exp = TopologyExplorer(body)
-        regions = top_exp.solids()
-        for region in regions:
-            region_index = self.entity_mapper.region_index(region)
-            region_indices.append(region_index)
+        lumps = top_exp.solids()
+        for lump in lumps:
+            lump_index = self.entity_mapper.lump_index(lump)
+            lump_indices.append(lump_index)
         return {
-            "regions": region_indices
+            "lumps": lump_indices
         }
 
-    def build_region_data(self, top_exp, region):
+    def build_lump_data(self, top_exp, lump):
         shell_indices = []
-        shells = top_exp._loop_topo(TopAbs_SHELL, region)
+        shells = top_exp._loop_topo(TopAbs_SHELL, lump)
         for shell in shells:
             shell_orientation = topology_utils.orientation_to_sense(shell.Orientation())
             shell_indices.append(self.entity_mapper.shell_index(shell))
@@ -172,7 +172,7 @@ class TopologyDictBuilder:
                 }
             )
         return {
-            "orientation_wrt_region": shell_orientation,
+            "orientation_wrt_lump": shell_orientation,
             "faces": face_list
         }
 
@@ -239,7 +239,8 @@ class TopologyDictBuilder:
 
     def build_loop_data(self, top_exp, loop):
         nr = top_exp.number_of_faces_from_wires(loop)
-        assert nr == 1
+        if not self.allow_nonmanifold:
+            assert nr == 1
         face = list(top_exp.faces_from_wire(loop))[0]
         saw = ShapeAnalysis_Wire(loop, face, 1e-8)
         #saw.Perform()

--- a/topology_dict_builder.py
+++ b/topology_dict_builder.py
@@ -36,7 +36,7 @@ class TopologyDictBuilder:
             bodies = [bodies]
             
         body_dict = {
-            "lumps": self.build_lumps_array(bodies),
+            "solids": self.build_solids_array(bodies),
             "shells": self.build_shells_array(bodies),
             "faces": self.build_faces_array(bodies),
             "edges": self.build_edges_array(bodies),
@@ -54,16 +54,16 @@ class TopologyDictBuilder:
             bodies_arr.append(self.build_body_data(body))
         return bodies_arr
 
-    def build_lumps_array(self, bodies):
-        lumps_arr = []
+    def build_solids_array(self, bodies):
+        solids_arr = []
         for body in bodies:
             top_exp = TopologyExplorer(body)
-            lumps = top_exp.solids()
-            for lump in lumps:
-                expected_lump_index = self.entity_mapper.lump_index(lump)
-                assert expected_lump_index == len(lumps_arr)
-                lumps_arr.append(self.build_lump_data(top_exp, lump))
-        return lumps_arr
+            solids = top_exp.solids()
+            for solid in solids:
+                expected_solid_index = self.entity_mapper.solid_index(solid)
+                assert expected_solid_index == len(solids_arr)
+                solids_arr.append(self.build_solid_data(top_exp, solid))
+        return solids_arr
         
 
     def build_shells_array(self, bodies):
@@ -132,19 +132,19 @@ class TopologyDictBuilder:
         return halfedges_arr
 
     def build_body_data(self, body):
-        lump_indices = []
+        solid_indices = []
         top_exp = TopologyExplorer(body)
-        lumps = top_exp.solids()
-        for lump in lumps:
-            lump_index = self.entity_mapper.lump_index(lump)
-            lump_indices.append(lump_index)
+        solids = top_exp.solids()
+        for solid in solids:
+            solid_index = self.entity_mapper.solid_index(solid)
+            solid_indices.append(solid_index)
         return {
-            "lumps": lump_indices
+            "solids": solid_indices
         }
 
-    def build_lump_data(self, top_exp, lump):
+    def build_solid_data(self, top_exp, solid):
         shell_indices = []
-        shells = top_exp._loop_topo(TopAbs_SHELL, lump)
+        shells = top_exp._loop_topo(TopAbs_SHELL, solid)
         for shell in shells:
             shell_orientation = topology_utils.orientation_to_sense(shell.Orientation())
             shell_indices.append(self.entity_mapper.shell_index(shell))
@@ -172,7 +172,7 @@ class TopologyDictBuilder:
                 }
             )
         return {
-            "orientation_wrt_lump": shell_orientation,
+            "orientation_wrt_solid": shell_orientation,
             "faces": face_list
         }
 

--- a/utest_topology_dict_builder.py
+++ b/utest_topology_dict_builder.py
@@ -599,7 +599,8 @@ class TopologyDictBuilderUtest(unittest.TestCase):
 
     def build_dict_for_bodies(self, bodies, expect_manifold):
         entity_mapper = EntityMapper(bodies)
-        dict_builder = TopologyDictBuilder(entity_mapper)
+        allow_non_manifold = not expect_manifold
+        dict_builder = TopologyDictBuilder(entity_mapper, allow_non_manifold)
         output = dict_builder.build_dict_for_bodies(bodies)
         for body in bodies:
             self.check_output_for_body(output, body, entity_mapper, expect_manifold)


### PR DESCRIPTION
# Why?

The terminology "regions" is typically used to describe solid or void regions of 3d space in a solid model.  This terminology is used in:

-  Parasolid
- Topological structures for geometric modeling, KJ Weiler
- Partial entity structure: A compact non-manifold boundary representation based on partial topological entities, Sang Hun Lee, Kunwoo Lee

In Open Cascade we don't have "void regions".  i.e. regions of 3d space which are not filled with solid material.  The term used in Open Cascade is solids.  We rename regions to solids here.
 
# What

- Rename regions to solids everywhere.
- Add a flag to indicate if we are expecting non-manifold bodies

